### PR TITLE
Fix verbatimModuleSyntax causes build failure due to missing type imports

### DIFF
--- a/src/components/FileUploadResult/FileUploadResult.tsx
+++ b/src/components/FileUploadResult/FileUploadResult.tsx
@@ -1,5 +1,5 @@
-import React, {ReactElement} from "react";
-import {FileUploadListProps, FileUploadListItem} from "../../../types";
+import React, {type ReactElement} from "react";
+import type {FileUploadListProps, FileUploadListItem} from "../../../types";
 
 export enum FileUploadStatus {
 	FAILED = "failed",


### PR DESCRIPTION
Fix [issue](https://github.com/Richard1320/React-Media-Library/issues/41)